### PR TITLE
WORKDIR issue in Hacker

### DIFF
--- a/hacker-notebook/Dockerfile
+++ b/hacker-notebook/Dockerfile
@@ -50,5 +50,7 @@ RUN pip install pyopenssl service_identity Twisted && \
 #copy the primary notebook
 COPY --chown=1000:100 Hacker.ipynb $HOME/
 
+WORKDIR $HOME
+
 CMD ["start-notebook.sh","--NotebookApp.token="]
 


### PR DESCRIPTION
Hacker was dropping user in sslstrip directory instead of the HOMEDIR where the Hacker.ipynb notebook is located. Added WORKDIR directive at end to have Jupyter start in home directory.