### PR TITLE
Dockerfile specifications for packages and WORKDIR for hacker

### DIFF
--- a/hacker-notebook/Dockerfile
+++ b/hacker-notebook/Dockerfile
@@ -7,13 +7,13 @@ USER root
 # Install the necessary networking tools
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
-    gcc \
+    gcc=4:7.4.0-1ubuntu2.2 \
     libc-dev \
-    dsniff \
-    inetutils-ping \
-    inetutils-traceroute \
-    net-tools \
-    iptables \
+    dsniff=2.4b1+debian-28.1~build1 \
+    inetutils-ping=2:1.9.4-3 \
+    inetutils-traceroute=2:1.9.4-3 \
+    net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+    iptables=1.6.1-2ubuntu2 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -42,13 +42,15 @@ COPY sslstrip /tmp
 WORKDIR /tmp
 
 # Install SSLStrip and its dependencies
-RUN pip install pyopenssl service_identity Twisted && \
-    python setup.py install && \
+RUN pip install pyopenssl==19.0.0 service_identity==18.1.0 Twisted==19.2.0 && \
+	python setup.py install && \
     rm -rf /tmp/sslstrip && \
     fix-permissions $CONDA_DIR
 
 #copy the primary notebook
 COPY --chown=1000:100 Hacker.ipynb $HOME/
+
+WORKDIR $HOME
 
 CMD ["start-notebook.sh","--NotebookApp.token="]
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,19 +10,19 @@ USER root
 # Install Apache2
 RUN apt-get update && \
     apt-get install -y \
-	apache2 \
-	apache2-utils \
-	libapache2-mod-wsgi-py3 \
-	ssl-cert \
-	net-tools \
-	supervisor
+	apache2=2.4.29-1ubuntu4.6 \
+	apache2-utils=2.4.29-1ubuntu4.6 \
+	libapache2-mod-wsgi-py3=4.5.17-1 \
+	ssl-cert=1.0.39 \
+	net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+	supervisor=3.3.1-1.1
 
 # Create the default directory
 RUN mkdir -p /srv/www/app
 
 # Clone the app and install packages
 ADD app /srv/www/app
-RUN pip install Flask
+RUN pip install Flask==1.0.3
 
 #copy conf files for our new app over to Apache's conf
 ADD conf /etc/apache2/sites-available

--- a/victim-vnc/Dockerfile
+++ b/victim-vnc/Dockerfile
@@ -3,7 +3,8 @@ FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
 MAINTAINER Rajesh Kalyanam "rkalyanapurdue@gmail.com"
 
 #add utilities to run ping and traceroute
-RUN apt-get update && apt-get -y install inetutils-ping inetutils-traceroute
+RUN apt-get update && apt-get -y install inetutils-ping=2:1.9.4-3 \
+	inetutils-traceroute=2:1.9.4-3
 
 #create a non-root user
 RUN useradd -d /home/victim -m -s /bin/bash victim


### PR DESCRIPTION
Added exact versions to packages in order to prevent updates that break labs. I did not specify libc-dev because it is a virtual package. Also added a fix for hacker-notebook, as Jupyter was not starting in the correct directory. I've tested these already while removing the previous containers in total (no cache), and there were no issues.

This closes #4 and closes #6  